### PR TITLE
ci: remove dead approve step from dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,12 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Approve PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Enable auto-merge
         run: gh pr merge --auto --squash --delete-branch "$PR_URL"
         env:


### PR DESCRIPTION
## Summary
- GitHub Actions isn't permitted to approve PRs on this repo (`can_approve_pull_request_reviews: false`), so the "Approve PR" step in `dependabot-auto-merge.yml` has failed on every dependabot PR since March.
- Branch protection on `main` only requires `backend-test`/`frontend-test` to pass — no review is required — so the approve step was dead weight.
- Removed it; auto-merge now just enables `gh pr merge --auto` directly.

## Test plan
- [x] CI passes on this PR
- [ ] Confirm future dependabot PRs merge automatically once checks pass